### PR TITLE
ASTERIXDB-2370: Modify the inconsistent method name "isFull".

### DIFF
--- a/asterixdb/asterix-replication/src/main/java/org/apache/asterix/replication/logging/ReplicationLogBuffer.java
+++ b/asterixdb/asterix-replication/src/main/java/org/apache/asterix/replication/logging/ReplicationLogBuffer.java
@@ -57,7 +57,7 @@ public class ReplicationLogBuffer {
         }
     }
 
-    public synchronized void isFull(boolean full) {
+    public synchronized void setFull(boolean full) {
         this.full.set(full);
         this.notify();
     }

--- a/asterixdb/asterix-replication/src/main/java/org/apache/asterix/replication/management/LogReplicationManager.java
+++ b/asterixdb/asterix-replication/src/main/java/org/apache/asterix/replication/management/LogReplicationManager.java
@@ -167,7 +167,7 @@ public class LogReplicationManager {
 
     private synchronized void appendToLogBuffer(ILogRecord logRecord) throws InterruptedException {
         if (!currentTxnLogBuffer.hasSpace(logRecord)) {
-            currentTxnLogBuffer.isFull(true);
+            currentTxnLogBuffer.setFull(true);
             if (logRecord.getLogSize() > logPageSize) {
                 getAndInitNewLargePage(logRecord.getLogSize());
             } else {


### PR DESCRIPTION
The method is named as "isFull".
However, the method does set the boolean-variable full.
Thus, rename the method as "setFull" should be more intuitive than "isFull" since "isFull" is a query asking whether the object is full or not.