### PR TITLE
Set proper inner dependency

### DIFF
--- a/asterixdb/asterix-doc/pom.xml
+++ b/asterixdb/asterix-doc/pom.xml
@@ -45,6 +45,13 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.asterix</groupId>
+            <artifactId>asterix-lang-sqlpp</artifactId>
+            <version>0.9.6-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <id>manual</id>


### PR DESCRIPTION
Setting this dependency, allows maven to do parallel builds, obviously improving building times.
`asterix-doc` needs at least one file (`SQLPP.HTML`) that is build by `asterix-lang-sqlpp`.