### PR TITLE
Update memory budget build

### DIFF
--- a/asterixdb/asterix-app/src/test/resources/cc.conf
+++ b/asterixdb/asterix-app/src/test/resources/cc.conf
@@ -19,17 +19,8 @@
 txn.log.dir=target/tmp/asterix_nc1/txnlog
 core.dump.dir=target/tmp/asterix_nc1/coredump
 iodevices=target/tmp/asterix_nc1/iodevice1,
-iodevices=../asterix-server/target/tmp/asterix_nc1/iodevice2
 nc.api.port=19004
 #jvm.args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006
-
-[nc/asterix_nc2]
-ncservice.port=9091
-txn.log.dir=target/tmp/asterix_nc2/txnlog
-core.dump.dir=target/tmp/asterix_nc2/coredump
-iodevices=target/tmp/asterix_nc2/iodevice1,../asterix-server/target/tmp/asterix_nc2/iodevice2
-nc.api.port=19005
-#jvm.args=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5007
 
 [nc]
 credential.file=src/test/resources/security/passwd

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePool.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePool.java
@@ -28,10 +28,10 @@ import org.apache.hyracks.api.exceptions.HyracksDataException;
 
 public class DeallocatableFramePool implements IDeallocatableFramePool {
 
-    private final IHyracksFrameMgrContext ctx;
-    private final int memBudget;
-    private int allocated;
-    private LinkedList<ByteBuffer> buffers;
+    protected final IHyracksFrameMgrContext ctx;
+    protected int memBudget;
+    protected int allocated;
+    protected LinkedList<ByteBuffer> buffers;
 
     public DeallocatableFramePool(IHyracksFrameMgrContext ctx, int memBudgetInBytes) {
         this.ctx = ctx;
@@ -107,6 +107,11 @@ public class DeallocatableFramePool implements IDeallocatableFramePool {
         } else {
             buffers.add(buffer);
         }
+    }
+
+    @Override
+    public boolean updateMemoryBudget(int newBudget) {
+        return false;
     }
 
     @Override

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
@@ -1,0 +1,40 @@
+package org.apache.hyracks.dataflow.std.buffermanager;
+
+import org.apache.hyracks.api.context.IHyracksFrameMgrContext;
+
+import java.nio.ByteBuffer;
+
+public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
+
+    int desiredBuffer = Integer.MAX_VALUE;
+    public DeallocatableFramePoolDynamicBudget(IHyracksFrameMgrContext ctx, int memBudgetInBytes) {
+        super(ctx, memBudgetInBytes);
+    }
+
+    @Override
+    public void deAllocateBuffer(ByteBuffer buffer) {
+        if (buffer.capacity() != ctx.getInitialFrameSize() || desiredBuffer < allocated) {
+            // simply deallocate the Big Object frame
+            ctx.deallocateFrames(buffer.capacity());
+            int framesReleased = buffer.capacity();
+            if(desiredBuffer < allocated){
+                memBudget = memBudget - framesReleased;
+                memBudget = memBudget < desiredBuffer ? desiredBuffer : memBudget;
+            }
+            allocated -= framesReleased;
+        } else {
+            buffers.add(buffer);
+        }
+    }
+
+    @Override
+    public boolean updateMemoryBudget(int newBudget){
+        desiredBuffer = newBudget * ctx.getInitialFrameSize();
+        if(this.allocated < newBudget){
+            this.memBudget = desiredBuffer; //Simply Update Memory Budget
+            return true;
+        }
+        return false; //There are more alocated Frames then the new Budget.
+    }
+
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/DeallocatableFramePoolDynamicBudget.java
@@ -30,7 +30,7 @@ public class DeallocatableFramePoolDynamicBudget extends DeallocatableFramePool{
     @Override
     public boolean updateMemoryBudget(int newBudget){
         desiredBuffer = newBudget * ctx.getInitialFrameSize();
-        if(this.allocated < newBudget){
+        if(this.allocated < desiredBuffer){
             this.memBudget = desiredBuffer; //Simply Update Memory Budget
             return true;
         }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IDeallocatableFramePool.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IDeallocatableFramePool.java
@@ -25,4 +25,6 @@ public interface IDeallocatableFramePool extends IFramePool {
 
     void deAllocateBuffer(ByteBuffer buffer);
 
+    boolean updateMemoryBudget(int newBudget);
+
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IPartitionedTupleBufferManager.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/IPartitionedTupleBufferManager.java
@@ -131,4 +131,6 @@ public interface IPartitionedTupleBufferManager {
     void clearPartition(int partition) throws HyracksDataException;
 
     IPartitionedMemoryConstrain getConstrain();
+
+    boolean updateMemoryBudget(int newBudget);
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/buffermanager/VPartitionTupleBufferManager.java
@@ -311,4 +311,9 @@ public class VPartitionTupleBufferManager implements IPartitionedTupleBufferMana
         return constrain;
     }
 
+    @Override
+    public boolean updateMemoryBudget(int newBudget){
+        return framePool.updateMemoryBudget(newBudget);
+    }
+
 }

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/IOptimizedHybridHashJoin.java
@@ -1,0 +1,52 @@
+package org.apache.hyracks.dataflow.std.join;
+
+import org.apache.hyracks.api.comm.IFrameWriter;
+import org.apache.hyracks.api.dataflow.value.ITuplePairComparator;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import org.apache.hyracks.api.job.profiling.IOperatorStats;
+import org.apache.hyracks.dataflow.common.io.RunFileReader;
+
+import java.nio.ByteBuffer;
+import java.util.BitSet;
+
+public interface IOptimizedHybridHashJoin {
+    void initBuild() throws HyracksDataException;
+
+    void build(ByteBuffer buffer) throws HyracksDataException;
+
+    void closeBuild() throws HyracksDataException;
+
+    void clearBuildTempFiles() throws HyracksDataException;
+
+    void clearProbeTempFiles() throws HyracksDataException;
+
+    void fail() throws HyracksDataException;
+
+    void initProbe(ITuplePairComparator comparator);
+
+    void probe(ByteBuffer buffer, IFrameWriter writer) throws HyracksDataException;
+
+    void completeProbe(IFrameWriter writer) throws HyracksDataException;
+
+    void releaseResource() throws HyracksDataException;
+
+    RunFileReader getBuildRFReader(int pid) throws HyracksDataException;
+
+    int getBuildPartitionSizeInTup(int pid);
+
+    RunFileReader getProbeRFReader(int pid) throws HyracksDataException;
+
+    int getProbePartitionSizeInTup(int pid);
+
+    int getMaxBuildPartitionSize();
+
+    int getMaxProbePartitionSize();
+
+    BitSet getPartitionStatus();
+
+    int getPartitionSize(int pid);
+
+    void setIsReversed(boolean reversed);
+
+    void setOperatorStats(IOperatorStats stats);
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/InMemoryHashJoin.java
@@ -55,7 +55,7 @@ public class InMemoryHashJoin {
     private ITuplePairComparator tpComparator;
     private final boolean isLeftOuter;
     private final ArrayTupleBuilder missingTupleBuild;
-    private final ISerializableTable table;
+    private ISerializableTable table;
     private final TuplePointer storedTuplePointer;
     private final boolean reverseOutputOrder; //Should we reverse the order of tuples, we are writing in output
     private final TupleInFrameListAccessor tupleAccessor;
@@ -220,6 +220,7 @@ public class InMemoryHashJoin {
     public void closeTable() throws HyracksDataException {
         table.close();
     }
+
 
     private void appendToResult(int probeSidetIx, int buildSidetIx, IFrameWriter writer) throws HyracksDataException {
         if (reverseOutputOrder) {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/MemoryContentionResponsiveHHJ.java
@@ -1,0 +1,86 @@
+package org.apache.hyracks.dataflow.std.join;
+
+import org.apache.hyracks.api.comm.IFrameWriter;
+import org.apache.hyracks.api.context.IHyracksJobletContext;
+import org.apache.hyracks.api.dataflow.value.IMissingWriterFactory;
+import org.apache.hyracks.api.dataflow.value.IPredicateEvaluator;
+import org.apache.hyracks.api.dataflow.value.ITuplePartitionComputer;
+import org.apache.hyracks.api.dataflow.value.RecordDescriptor;
+import org.apache.hyracks.api.exceptions.HyracksDataException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class MemoryContentionResponsiveHHJ extends OptimizedHybridHashJoin {
+    private int processedFrames = 0;
+    private int frameInterval = 0;
+    private boolean eventBased = false;
+    private int timeInterval =0;
+    private Timer timer;
+
+    /**
+     * Timer Task to update Memory Budget when running on Time Strategy.
+     */
+    class UpdateMemoryTask extends TimerTask {
+        public void run() {
+            LOGGER.info("Update Memory Budget Based on TIME");
+            updateMemoryBudgetBuildPhase();
+        }
+    }
+
+    public MemoryContentionResponsiveHHJ(IHyracksJobletContext jobletCtx, int memSizeInFrames, int numOfPartitions, String probeRelName, String buildRelName, RecordDescriptor probeRd, RecordDescriptor buildRd, ITuplePartitionComputer probeHpc, ITuplePartitionComputer buildHpc, IPredicateEvaluator probePredEval, IPredicateEvaluator buildPredEval, boolean isLeftOuter, IMissingWriterFactory[] nullWriterFactories1,int timeInterval,int frameInterval,boolean eventBased) {
+        super(jobletCtx, memSizeInFrames, numOfPartitions, probeRelName, buildRelName, probeRd, buildRd, probeHpc, buildHpc, probePredEval, buildPredEval, isLeftOuter, nullWriterFactories1);
+        SetTimeInterval(timeInterval);
+        this.frameInterval = frameInterval;
+        this.eventBased = eventBased;
+    }
+
+    private void SetTimeInterval(int interval){
+        timeInterval = interval;
+        if(interval > 0) {
+            if (timer == null) {
+                timer = new Timer("Update Budget");
+            } else {
+                timer.cancel();
+            }
+            timer.schedule(new UpdateMemoryTask(), 0, timeInterval);
+        }
+        else if(timer != null){
+            timer.cancel();
+        }
+    }
+
+    public void build(ByteBuffer buffer)  throws HyracksDataException {
+        if(frameInterval > 0 && processedFrames % frameInterval == 0){
+            LOGGER.info("Update Memory Budget Based on FRAME");
+            updateMemoryBudgetBuildPhase();
+        }
+        super.build(buffer);
+        processedFrames++;
+    }
+
+    /**
+     * Updates Memory Budget During Build Phase
+     */
+    private void updateMemoryBudgetBuildPhase(){
+        int newBudget = new Random().nextInt(2*memSizeInFrames)+ this.memSizeInFrames;
+    }
+
+    @Override
+    public void spillPartition(int pid) throws HyracksDataException {
+        if(eventBased){
+            LOGGER.info("Update Memory Budget Based on EVENT");
+            updateMemoryBudgetBuildPhase();
+        }
+        super.spillPartition(pid);
+    }
+    @Override
+    public void completeProbe(IFrameWriter writer) throws HyracksDataException {
+        super.completeProbe(writer);
+        LOGGER.info("Complete HHJ Round");
+        if(timer != null) {
+            timer.cancel();
+        }
+    }
+}

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,8 +145,6 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int frameInterval = 10;
-    private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,
             int inputsize0, double factor, int[] keys0, int[] keys1,
@@ -232,7 +230,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
 
         private int memForJoin;
         private int numOfPartitions;
-        private IOptimizedHybridHashJoin hybridHJ;
+        private OptimizedHybridHashJoin hybridHJ;
 
         public BuildAndPartitionTaskState() {
         }
@@ -304,7 +302,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                             getNumberOfPartitions(state.memForJoin, inputsize0, fudgeFactor, nPartitions);
                     state.hybridHJ = new MemoryContentionResponsiveHHJ(ctx.getJobletContext(), state.memForJoin,
                             state.numOfPartitions, PROBE_REL, BUILD_REL, probeRd, buildRd, probeHpc, buildHpc,
-                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased);
+                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories);
                     state.hybridHJ.setOperatorStats(stats);
 
                     state.hybridHJ.initBuild();
@@ -615,10 +613,10 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                     boolean isReversed = probeKeys == OptimizedHybridHashJoinOperatorDescriptor.this.buildKeys
                             && buildKeys == OptimizedHybridHashJoinOperatorDescriptor.this.probeKeys;
                     assert isLeftOuter ? !isReversed : true : "LeftOut Join can not reverse roles";
-                    IOptimizedHybridHashJoin rHHj;
+                    OptimizedHybridHashJoin rHHj;
                     int n = getNumberOfPartitions(state.memForJoin, tableSize, fudgeFactor, nPartitions);
                     rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL, probeRd,
-                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased); //checked-confirmed
+                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories); //checked-confirmed
 
                     rHHj.setIsReversed(isReversed);
                     try {

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,8 +145,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int timeInterval = 100;
-    private int frameInterval = 10;
+    private int frameInterval = 0;
     private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,

--- a/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
+++ b/hyracks-fullstack/hyracks/hyracks-dataflow-std/src/main/java/org/apache/hyracks/dataflow/std/join/OptimizedHybridHashJoinOperatorDescriptor.java
@@ -145,7 +145,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
     private boolean forceRoleReversal = false;
 
     private static final Logger LOGGER = LogManager.getLogger();
-    private int frameInterval = 0;
+    private int frameInterval = 10;
     private  boolean eventBased = false;
 
     public OptimizedHybridHashJoinOperatorDescriptor(IOperatorDescriptorRegistry spec, int memSizeInFrames,
@@ -304,7 +304,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                             getNumberOfPartitions(state.memForJoin, inputsize0, fudgeFactor, nPartitions);
                     state.hybridHJ = new MemoryContentionResponsiveHHJ(ctx.getJobletContext(), state.memForJoin,
                             state.numOfPartitions, PROBE_REL, BUILD_REL, probeRd, buildRd, probeHpc, buildHpc,
-                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,timeInterval,frameInterval,eventBased);
+                            probePredEval, buildPredEval, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased);
                     state.hybridHJ.setOperatorStats(stats);
 
                     state.hybridHJ.initBuild();
@@ -618,7 +618,7 @@ public class OptimizedHybridHashJoinOperatorDescriptor extends AbstractOperatorD
                     IOptimizedHybridHashJoin rHHj;
                     int n = getNumberOfPartitions(state.memForJoin, tableSize, fudgeFactor, nPartitions);
                     rHHj = new MemoryContentionResponsiveHHJ(jobletCtx, state.memForJoin, n, PROBE_REL, BUILD_REL, probeRd,
-                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,timeInterval,frameInterval,eventBased); //checked-confirmed
+                            buildRd, probeHpc, buildHpc, null, null, isLeftOuter, nonMatchWriterFactories,frameInterval,eventBased); //checked-confirmed
 
                     rHHj.setIsReversed(isReversed);
                     try {


### PR DESCRIPTION
Working version, still getting some errors in calculating the free space before reloading partitions after a memory expansion during the PROBE Phase.

Data Used to test:
4 data partitions were built using Winsconsin Data Generator. 

Queries Used to test:
Simple Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {W1.unique1, W2.unique1} fields.
Simple Join filtering the [100, 1000] entries selecting all fields.

3-Way Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {W1.unique1, W2.unique1,W3.unique1} fields.
3-Way Join filtering the [100, 1000] entries selecting all fields.

4-Way Join filtering the [100, 1000, 5000, 20000, 50000] entries selecting only {{W1.unique1, W2.unique1,W3.unique1,W4.unique1}  fields.
4-Way Join filtering the [100, 1000] entries selecting all fields.


#LOG BEFORE ERROR:
![Screenshot from 2023-07-16 11-51-38](https://github.com/apache/asterixdb/assets/98982283/c697b305-88b9-490f-bcef-c8dbefcf8d05)

Note the last line, the "FREE SPACE" is smaller the sum of "HASH TABLE" and "PARTITION"

I tried creating a new method to Calculate the Free space using the actual size of the HASH TABLE, but got the same error.