### PR TITLE
fixed a few ebnf errors

### DIFF
--- a/asterixdb/asterix-doc/src/main/grammar/sqlpp.ebnf
+++ b/asterixdb/asterix-doc/src/main/grammar/sqlpp.ebnf
@@ -30,7 +30,7 @@ ParenthesizedExpr ::= ("(" Expr ")") | Subquery
 
 FunctionCall ::= OrdinaryFunctionCall | AggregateFunctionCall | WindowFunctionCall
 
-OrdinaryFunctionCall ::= (DataverseName ".")? Identifier "(" Expr ("," Expr)* ")"
+OrdinaryFunctionCall ::= (DataverseName ".")? Identifier "(" (Expr ("," Expr)*)? ")"
 
 AggregateFunctionCall ::= Identifier "(" ("DISTINCT")? Expr ")" ("FILTER" "(" "WHERE" Expr ")")?
 
@@ -91,13 +91,11 @@ GroupAsClause ::= "GROUP AS" Variable
 
 HavingClause ::= "HAVING" Expr
 
-Selection ::= WithClause? QueryBlock UnionOption* OrderByClause? ( LimitClause | OffsetClause )?
-
 UnionOption ::= "UNION ALL" (QueryBlock | Subquery)
 
 WithClause ::= "WITH" Variable "AS" Expr ("," Variable "AS" Expr)*
 
-OrderbyClause ::= "ORDER BY" Expr ( "ASC" | "DESC" )? ( "NULLS" ( "FIRST" | "LAST" ) )? ( "," Expr ( "ASC" | "DESC" )? ( "NULLS" ( "FIRST" | "LAST" ) )? )*
+OrderByClause ::= "ORDER BY" Expr ( "ASC" | "DESC" )? ( "NULLS" ( "FIRST" | "LAST" ) )? ( "," Expr ( "ASC" | "DESC" )? ( "NULLS" ( "FIRST" | "LAST" ) )? )*
 
 LimitClause ::= "LIMIT" Expr OffsetClause?
 
@@ -259,8 +257,8 @@ InsertStmnt ::= "INSERT" "INTO" QualifiedName ("AS" Variable)? Query ("RETURNING
 UpsertStmnt ::= "UPSERT" "INTO" QualifiedName ("AS" Variable)? Query ("RETURNING" Expr)?
 
 
-CopyStmnt ::= "COPY" "INTO"? QualifiedName ("AS" Variable)? "FROM" Identifier "AT" QualifiedName ("PATH" StringLiteral)? (WITH ObjectConstructor)?
+CopyStmnt ::= "COPY" "INTO"? QualifiedName ("AS" Variable)? "FROM" Identifier "AT" QualifiedName ("PATH" StringLiteral)? ("WITH" ObjectConstructor)?
 
-CopyToStmnt ::= "COPY" ( QualifiedName | "(" Query ")" ) "TO" AdapterName "PATH" ParenthesizedArrayConstructor ("OVER" "(" ("PARTITION" "BY" Expr ("AS" Variable)? ("," Expr ("AS" Variable)? )? )? OrderbyClause ")" )? WITH ObjectConstructor
+CopyToStmnt ::= "COPY" ( QualifiedName | "(" Query ")" ) "TO" AdapterName "PATH" ParenthesizedArrayConstructor ("OVER" "(" ("PARTITION" "BY" Expr ("AS" Variable)? ("," Expr ("AS" Variable)? )? )? OrderByClause ")" )? "WITH" ObjectConstructor
 
 DeleteStmnt ::= "DELETE" "FROM" QualifiedName (("AS")? Variable)? ("WHERE" Expr)?


### PR DESCRIPTION
## Well detailed description of the change:

There are a few errors in the sqlpp.ebnf description of the language that I fixed:
1.  The OrdinaryFunctionCall should be able to have no arguments.
There are functions in asterixdb, like current_time(), that don't have any arguments.  I changed to the ebnf to allow that.

2.  A duplicate description of the Selection rule. 
One contained the ability to use a LetClause and the other didn't.  I deleted the one that didn't as asterixdb does support LetClauses.  

3.  Case typo in OrderByClause.
The OrderByClause non-terminal was written in 2 different ways: OrderbyClause and OrderByClause.  I changed them all to OrderByClause (consistent with GroupByClause)

4.  The non-Terminal "WITH" was used without the quotes.
In 2 rules, the keyword "WITH" was written without the quotes.  I added them. 

## Context of the change
I'm writing a parser generator for sqlpp in flex/bison using this ebnf and I ran into these errors. I'm not sure if this file is used to generate a parser or just as documentation, but I thought it would be useful to fix these.  

