### PR TITLE
Fix: preserve query input when switching dataverse; replace leading USE statement (ASTERIXDB-3124)

### DIFF
--- a/asterixdb/asterix-dashboard/src/node/src/app/dashboard/query/input.component.ts
+++ b/asterixdb/asterix-dashboard/src/node/src/app/dashboard/query/input.component.ts
@@ -532,16 +532,26 @@
     }
 
     dataverseSelected() {
-      if (this.selected == undefined) {
-        this.queryString = 'None';
-      } else if (this.selected === 'None' || this.selected === 'Default') {
-        this.queryString = '';
+      if (this.selected == undefined) return;
+
+      const useStmt = 'USE ' + this.selected + ';\n';
+      let qs = this.queryString || '';
+      const leadingUseRegex = /^\s*USE\s+[^;]+;\s*/i;
+
+      if (this.selected === 'None' || this.selected === 'Default') {
+        qs = qs.replace(leadingUseRegex, '');
         this.selected = 'Default';
       } else {
-        this.queryString = 'USE ' + this.selected + '; \n' + this.queryString;
+        if (leadingUseRegex.test(qs)) {
+          qs = qs.replace(leadingUseRegex, useStmt);
+        } else {
+          qs = useStmt + qs;
+        }
       }
+
+      this.queryString = qs;
       this.editor.getDoc().setValue(this.queryString);
-      this.editor.execCommand('goDocEnd')
+      this.editor.execCommand('goDocEnd');
       this.editor.focus();
     }
 


### PR DESCRIPTION
This PR fixes an issue where selecting a different dataverse from the dropdown would overwrite the current query in the editor with a USE statement, causing loss of user input.

With this change, the query editor now preserves the existing query text when the dataverse selection changes. Instead of replacing the query, the logic updates or prepends the appropriate USE statement only when necessary.

🔧 Changes Made
Updated the dataverseSelected() handler in the Angular dashboard.
Preserved the existing query string instead of overwriting it.
Replaced the leading USE statement if present, otherwise prepended it.
Removed the USE statement when switching to Default or None.

✅ How to Test
Open the AsterixDB dashboard (Angular UI).
Enter a query in the editor (e.g., SELECT * FROM Metadata.Dataset;).
Change the dataverse using the dropdown.
Verify:
The existing query is preserved.
The USE <dataverse>; statement is correctly updated or inserted.
Switching to Default removes any existing USE statement.