### PR TITLE
ASTERIXDB-PR1: Bootstrap asterix-spidersilk module with NL2SQL++ serv…

### DIFF
--- a/asterixdb/asterix-app/src/main/java/org/apache/asterix/hyracks/bootstrap/CCApplication.java
+++ b/asterixdb/asterix-app/src/main/java/org/apache/asterix/hyracks/bootstrap/CCApplication.java
@@ -41,6 +41,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.asterix.api.http.IApiServerRegistrant;
 import org.apache.asterix.api.http.IQueryWebServerRegistrant;
 import org.apache.asterix.api.http.server.ActiveRequestsServlet;
 import org.apache.asterix.api.http.server.ActiveStatsApiServlet;
@@ -361,6 +362,9 @@ public class CCApplication extends BaseCCApplication {
         addServlet(jsonAPIServer, Servlets.CLUSTER_STATE_CC_DETAIL); // must not precede add of CLUSTER_STATE
         addServlet(jsonAPIServer, Servlets.DIAGNOSTICS);
         addServlet(jsonAPIServer, Servlets.ACTIVE_STATS);
+        // Load extension servlets registered via ServiceLoader (e.g., NL2SQL++ from asterix-spidersilk)
+        ServiceLoader.load(IApiServerRegistrant.class)
+                .forEach(registrant -> registrant.register(appCtx, jsonAPIServer));
         return jsonAPIServer;
     }
 

--- a/asterixdb/asterix-common/src/main/java/org/apache/asterix/api/http/IApiServerRegistrant.java
+++ b/asterixdb/asterix-common/src/main/java/org/apache/asterix/api/http/IApiServerRegistrant.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.api.http;
+
+/**
+ * Extension point for registering servlets on the JSON API server (default port 19002).
+ * Implementations are discovered via {@link java.util.ServiceLoader}.
+ *
+ * To register a servlet, create an implementation of this interface and declare it in:
+ * {@code META-INF/services/org.apache.asterix.api.http.IApiServerRegistrant}
+ *
+ * @see IQueryWebServerRegistrant for the equivalent mechanism on the query web server (port 19006)
+ */
+public interface IApiServerRegistrant extends IServletRegistrant {
+}

--- a/asterixdb/asterix-common/src/main/java/org/apache/asterix/common/utils/Servlets.java
+++ b/asterixdb/asterix-common/src/main/java/org/apache/asterix/common/utils/Servlets.java
@@ -23,6 +23,7 @@ public class Servlets {
     public static final String QUERY_STATUS = "/query/service/status/*";
     public static final String QUERY_RESULT = "/query/service/result/*";
     public static final String QUERY_SERVICE = "/query/service";
+    public static final String NL2SQL_SERVICE = "/query/nl2sql";
     public static final String CONNECTOR = "/connector";
     public static final String REBALANCE = "/admin/rebalance";
     public static final String SHUTDOWN = "/admin/shutdown";

--- a/asterixdb/asterix-spidersilk/pom.xml
+++ b/asterixdb/asterix-spidersilk/pom.xml
@@ -21,11 +21,55 @@
   <artifactId>asterix-spidersilk</artifactId>
   <name>asterix-spidersilk</name>
 
+  <properties>
+    <root.dir>${basedir}/..</root.dir>
+  </properties>
+
   <parent>
     <groupId>org.apache.asterix</groupId>
     <artifactId>apache-asterixdb</artifactId>
     <version>0.9.10-SNAPSHOT</version>
   </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.asterix</groupId>
+      <artifactId>asterix-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.asterix</groupId>
+      <artifactId>asterix-metadata</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.asterix</groupId>
+      <artifactId>asterix-om</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hyracks</groupId>
+      <artifactId>hyracks-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>

--- a/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/INl2SqlTranslator.java
+++ b/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/INl2SqlTranslator.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk.api;
+
+/**
+ * Core interface for natural language to SQL++ translation.
+ *
+ * Implementations are model-agnostic: any LLM backend (OpenAI, Ollama, etc.)
+ * can be used by providing a different implementation. The LangChain4j framework
+ * is used internally to manage LLM communication, prompt templating, and retries.
+ *
+ * <p>Usage example:
+ * <pre>
+ *   INl2SqlTranslator translator = new LangChain4jTranslator(config);
+ *   SchemaContext schema = schemaBuilder.buildContext("TinySocial");
+ *   String sqlpp = translator.translate("Find all tweets mentioning AsterixDB", schema);
+ *   // sqlpp => "SELECT VALUE t FROM TweetMessages t WHERE t.message_text LIKE '%AsterixDB%'"
+ * </pre>
+ */
+public interface INl2SqlTranslator {
+
+    /**
+     * Translates a natural language query into an executable SQL++ statement.
+     *
+     * The implementation should:
+     * <ol>
+     *   <li>Build a schema-aware prompt from {@code schemaContext}</li>
+     *   <li>Call the configured LLM to generate a SQL++ candidate</li>
+     *   <li>Validate the candidate using the AsterixDB SQL++ parser</li>
+     *   <li>Retry with error feedback if validation fails (up to a configured max)</li>
+     * </ol>
+     *
+     * @param naturalLanguage the user's natural language query (non-null, non-empty)
+     * @param schemaContext   schema information for the target dataverse; may be
+     *                        {@code null} if no dataverse is specified
+     * @return a syntactically valid SQL++ query string
+     * @throws Nl2SqlException if translation fails after exhausting retries,
+     *                         or if the LLM service is unavailable
+     */
+    String translate(String naturalLanguage, SchemaContext schemaContext) throws Nl2SqlException;
+}

--- a/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/Nl2SqlException.java
+++ b/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/Nl2SqlException.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk.api;
+
+/**
+ * Thrown when natural language to SQL++ translation fails.
+ * Common causes:
+ * <ul>
+ *   <li>LLM service unavailable or misconfigured</li>
+ *   <li>Generated SQL++ fails syntax validation after max retries</li>
+ *   <li>Input natural language query is ambiguous or unsupported</li>
+ * </ul>
+ */
+public class Nl2SqlException extends Exception {
+
+    private static final long serialVersionUID = 1L;
+
+    public Nl2SqlException(String message) {
+        super(message);
+    }
+
+    public Nl2SqlException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/SchemaContext.java
+++ b/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/api/SchemaContext.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk.api;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Encapsulates the database schema information extracted from AsterixDB metadata.
+ * This context is injected into the LLM prompt to enable schema-aware SQL++ generation.
+ *
+ * The schema is extracted from the {@code asterix-metadata} module via MetadataManager,
+ * including Dataset definitions, type information, and index metadata.
+ */
+public class SchemaContext {
+
+    private final String dataverse;
+    private final List<String> datasetDescriptions;
+
+    public SchemaContext(String dataverse, List<String> datasetDescriptions) {
+        this.dataverse = dataverse;
+        this.datasetDescriptions = Collections.unmodifiableList(new java.util.ArrayList<>(datasetDescriptions));
+    }
+
+    /**
+     * @return the target dataverse name
+     */
+    public String getDataverse() {
+        return dataverse;
+    }
+
+    /**
+     * @return human-readable schema descriptions for each dataset in the dataverse,
+     *         formatted for inclusion in an LLM prompt
+     */
+    public List<String> getDatasetDescriptions() {
+        return datasetDescriptions;
+    }
+
+    /**
+     * Renders the schema context as a prompt-ready string.
+     * Example output:
+     * <pre>
+     * Dataverse: TinySocial
+     * Dataset TweetMessages (tweetid: bigint, sender-location: point, text: string, ...)
+     * Dataset FacebookUsers (id: bigint, name: string, employment: [object], ...)
+     * </pre>
+     */
+    public String toPromptString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Dataverse: ").append(dataverse).append('\n');
+        for (String desc : datasetDescriptions) {
+            sb.append(desc).append('\n');
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "SchemaContext{dataverse='" + dataverse + "', datasets=" + datasetDescriptions.size() + "}";
+    }
+}

--- a/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/servlet/NL2SqlServlet.java
+++ b/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/servlet/NL2SqlServlet.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.asterix.spidersilk.api.INl2SqlTranslator;
+import org.apache.asterix.spidersilk.api.Nl2SqlException;
+import org.apache.asterix.spidersilk.api.SchemaContext;
+import org.apache.hyracks.http.api.IServletRequest;
+import org.apache.hyracks.http.api.IServletResponse;
+import org.apache.hyracks.http.server.AbstractServlet;
+import org.apache.hyracks.http.server.utils.HttpUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+/**
+ * HTTP servlet exposing the NL2SQL++ translation API on the JSON API server.
+ *
+ * <p><b>Endpoint:</b> {@code POST /query/nl2sql}
+ *
+ * <p><b>Request parameters (form or JSON body):</b>
+ * <ul>
+ *   <li>{@code statement} (required) — the natural language query</li>
+ *   <li>{@code dataverse} (optional) — target dataverse for schema context</li>
+ * </ul>
+ *
+ * <p><b>Response (JSON):</b>
+ * <pre>
+ * {
+ *   "sqlpp":   "SELECT VALUE t FROM TweetMessages t WHERE ...",
+ *   "status":  "success"
+ * }
+ * </pre>
+ *
+ * <p>When the {@code INl2SqlTranslator} implementation is not yet available,
+ * the endpoint returns HTTP 501 (Not Implemented) with an informative message,
+ * allowing the servlet to be registered and tested without a live LLM backend.
+ */
+public class NL2SqlServlet extends AbstractServlet {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    /** Request parameter name for the natural language query. */
+    public static final String PARAM_STATEMENT = "statement";
+    /** Optional request parameter specifying the target dataverse. */
+    public static final String PARAM_DATAVERSE = "dataverse";
+
+    /**
+     * The translator is injected at construction time and may be {@code null}
+     * until a concrete LLM implementation is provided (Phase 2 of development).
+     */
+    private final INl2SqlTranslator translator;
+
+    public NL2SqlServlet(ConcurrentMap<String, Object> ctx, String[] paths, INl2SqlTranslator translator) {
+        super(ctx, paths);
+        this.translator = translator;
+    }
+
+    @Override
+    protected void post(IServletRequest request, IServletResponse response) throws IOException {
+        String naturalLanguage = request.getParameter(PARAM_STATEMENT);
+        String dataverse = request.getParameter(PARAM_DATAVERSE);
+
+        if (naturalLanguage == null || naturalLanguage.isBlank()) {
+            sendError(request, response, HttpResponseStatus.BAD_REQUEST, "Parameter 'statement' is required.");
+            return;
+        }
+
+        if (translator == null) {
+            sendError(request, response, HttpResponseStatus.NOT_IMPLEMENTED,
+                    "NL2SQL++ translator is not yet configured. "
+                            + "Set nl2sql.model.type and related properties in cc.conf and restart the server.");
+            return;
+        }
+
+        try {
+            // Build schema context from metadata if a dataverse is provided.
+            // SchemaContextBuilder integration will be added in the next phase.
+            SchemaContext schemaContext = dataverse != null ? new SchemaContext(dataverse, java.util.List.of()) : null;
+
+            String sqlpp = translator.translate(naturalLanguage, schemaContext);
+
+            HttpUtil.setContentType(response, HttpUtil.ContentType.APPLICATION_JSON, request);
+            response.setStatus(HttpResponseStatus.OK);
+
+            ObjectNode result = OBJECT_MAPPER.createObjectNode();
+            result.put("sqlpp", sqlpp);
+            result.put("status", "success");
+
+            PrintWriter writer = response.writer();
+            writer.write(result.toString());
+            writer.flush();
+
+        } catch (Nl2SqlException e) {
+            LOGGER.warn("NL2SQL translation failed for query: {}", naturalLanguage, e);
+            sendError(request, response, HttpResponseStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+
+    @Override
+    protected void get(IServletRequest request, IServletResponse response) throws IOException {
+        sendError(request, response, HttpResponseStatus.METHOD_NOT_ALLOWED, "Use POST with parameter 'statement'.");
+    }
+
+    private void sendError(IServletRequest request, IServletResponse response, HttpResponseStatus status,
+            String message) throws IOException {
+        HttpUtil.setContentType(response, HttpUtil.ContentType.APPLICATION_JSON, request);
+        response.setStatus(status);
+        ObjectNode error = OBJECT_MAPPER.createObjectNode();
+        error.put("status", "error");
+        error.put("message", message);
+        PrintWriter writer = response.writer();
+        writer.write(error.toString());
+        writer.flush();
+    }
+}

--- a/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/servlet/NL2SqlServletRegistrant.java
+++ b/asterixdb/asterix-spidersilk/src/main/java/org/apache/asterix/spidersilk/servlet/NL2SqlServletRegistrant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk.servlet;
+
+import org.apache.asterix.api.http.IApiServerRegistrant;
+import org.apache.asterix.common.dataflow.ICcApplicationContext;
+import org.apache.asterix.common.utils.Servlets;
+import org.apache.hyracks.http.server.HttpServer;
+
+/**
+ * Registers the {@link NL2SqlServlet} on the JSON API server via the
+ * {@link IApiServerRegistrant} ServiceLoader extension point.
+ *
+ * This class is discovered automatically at runtime through:
+ * {@code META-INF/services/org.apache.asterix.api.http.IApiServerRegistrant}
+ *
+ * No modification to {@code CCApplication.java} is required beyond the
+ * one-time addition of the ServiceLoader call in {@code setupJSONAPIServer()}.
+ */
+public class NL2SqlServletRegistrant implements IApiServerRegistrant {
+
+    @Override
+    public void register(ICcApplicationContext appCtx, HttpServer apiServer) {
+        // The translator is null here; it will be initialized from configuration
+        // in a follow-up phase when LangChain4j integration is added.
+        apiServer.addServlet(new NL2SqlServlet(apiServer.ctx(), new String[] { Servlets.NL2SQL_SERVICE }, null));
+    }
+}

--- a/asterixdb/asterix-spidersilk/src/main/resources/META-INF/services/org.apache.asterix.api.http.IApiServerRegistrant
+++ b/asterixdb/asterix-spidersilk/src/main/resources/META-INF/services/org.apache.asterix.api.http.IApiServerRegistrant
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+org.apache.asterix.spidersilk.servlet.NL2SqlServletRegistrant

--- a/asterixdb/asterix-spidersilk/src/test/java/org/apache/asterix/spidersilk/NL2SqlServletTest.java
+++ b/asterixdb/asterix-spidersilk/src/test/java/org/apache/asterix/spidersilk/NL2SqlServletTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.asterix.spidersilk;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.asterix.spidersilk.api.INl2SqlTranslator;
+import org.apache.asterix.spidersilk.api.Nl2SqlException;
+import org.apache.asterix.spidersilk.api.SchemaContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit tests for the NL2SQL++ module skeleton.
+ *
+ * These tests verify the core API contracts without requiring a running AsterixDB
+ * instance or a live LLM service. Full integration tests will be added in Phase 2
+ * when LangChain4j translation is implemented.
+ */
+public class NL2SqlServletTest {
+
+    @Test
+    public void testSchemaContextToPromptString() {
+        SchemaContext ctx =
+                new SchemaContext("TinySocial", Arrays.asList("Dataset TweetMessages (tweetid: bigint, text: string)",
+                        "Dataset FacebookUsers (id: bigint, name: string)"));
+
+        String prompt = ctx.toPromptString();
+
+        Assert.assertTrue("Prompt should contain dataverse name", prompt.contains("TinySocial"));
+        Assert.assertTrue("Prompt should contain TweetMessages dataset", prompt.contains("TweetMessages"));
+        Assert.assertTrue("Prompt should contain FacebookUsers dataset", prompt.contains("FacebookUsers"));
+    }
+
+    @Test
+    public void testSchemaContextImmutable() {
+        List<String> descriptions = new ArrayList<>();
+        descriptions.add("Dataset Foo (id: bigint)");
+        SchemaContext ctx = new SchemaContext("TestDV", descriptions);
+
+        // Modifying the original list should not affect the SchemaContext
+        descriptions.add("Dataset Bar (id: bigint)");
+
+        Assert.assertEquals("SchemaContext should hold an immutable copy of the descriptions", 1,
+                ctx.getDatasetDescriptions().size());
+    }
+
+    @Test
+    public void testNl2SqlExceptionMessage() {
+        Nl2SqlException ex = new Nl2SqlException("LLM service unavailable");
+        Assert.assertEquals("LLM service unavailable", ex.getMessage());
+    }
+
+    @Test
+    public void testNl2SqlExceptionWithCause() {
+        RuntimeException cause = new RuntimeException("connection refused");
+        Nl2SqlException ex = new Nl2SqlException("Translation failed", cause);
+
+        Assert.assertEquals("Translation failed", ex.getMessage());
+        Assert.assertSame(cause, ex.getCause());
+    }
+
+    /**
+     * Verifies that a mock implementation of INl2SqlTranslator correctly
+     * returns a SQL++ string. This ensures the interface contract is stable.
+     */
+    @Test
+    public void testTranslatorInterfaceContract() throws Nl2SqlException {
+        INl2SqlTranslator mockTranslator =
+                (nl, schema) -> "SELECT VALUE t FROM TweetMessages t WHERE t.text LIKE '%" + nl + "%'";
+
+        SchemaContext ctx =
+                new SchemaContext("TinySocial", Arrays.asList("Dataset TweetMessages (tweetid: bigint, text: string)"));
+
+        String result = mockTranslator.translate("AsterixDB", ctx);
+
+        Assert.assertNotNull("Translator must return a non-null SQL++ string", result);
+        Assert.assertTrue("Result should reference the dataset", result.contains("TweetMessages"));
+        Assert.assertTrue("Result should be a SELECT statement", result.startsWith("SELECT"));
+    }
+}


### PR DESCRIPTION
## Summary
                                                                                                                                                                 
  Bootstrap the `asterix-spidersilk` module as the first step of the
  GSoC 2026 NL2SQL++ project.                                                                                                                                    
                             
  ### Changes                                                                                                                                                    
  - Add `IApiServerRegistrant` ServiceLoader extension point to register
    servlets on the JSON API server without modifying `CCApplication.java`                                                                                       
  - Add core interfaces: `INl2SqlTranslator`, `SchemaContext`, `Nl2SqlException`                                                                                 
  - Register a skeleton `NL2SqlServlet` on `POST /query/nl2sql` (port 19002)                                                                                     
  - Add unit tests covering the core API contracts                                                                                                               
                                                                                                                                                                 
  ### Testing                                                                                                                                                    
  All unit tests pass: `mvn test -pl asterixdb/asterix-spidersilk` 