### PR TITLE
[ASTERIXDB-3021][COMP] Emit cross product warning for implicit joins

### DIFF
--- a/hyracks-fullstack/algebricks/algebricks-rewriter/src/main/java/org/apache/hyracks/algebricks/rewriter/rules/SimpleUnnestToProductRule.java
+++ b/hyracks-fullstack/algebricks/algebricks-rewriter/src/main/java/org/apache/hyracks/algebricks/rewriter/rules/SimpleUnnestToProductRule.java
@@ -37,6 +37,7 @@ import org.apache.hyracks.algebricks.core.algebra.operators.logical.InnerJoinOpe
 import org.apache.hyracks.algebricks.core.algebra.operators.logical.visitors.VariableUtilities;
 import org.apache.hyracks.algebricks.core.algebra.util.OperatorPropertiesUtil;
 import org.apache.hyracks.algebricks.core.rewriter.base.IAlgebraicRewriteRule;
+import org.apache.hyracks.algebricks.rewriter.util.JoinUtils;
 
 public class SimpleUnnestToProductRule implements IAlgebraicRewriteRule {
 
@@ -142,6 +143,8 @@ public class SimpleUnnestToProductRule implements IAlgebraicRewriteRule {
         context.computeAndSetTypeEnvironmentForOperator(boundaryOperator);
         context.computeAndSetTypeEnvironmentForOperator(innerBranchOperator);
         context.computeAndSetTypeEnvironmentForOperator(join);
+        JoinUtils.warnIfCrossProduct(join.getCondition().getValue(),
+                innerBranchOperator.getSourceLocation(), context);
         return true;
     }
 

--- a/hyracks-fullstack/algebricks/algebricks-rewriter/src/main/java/org/apache/hyracks/algebricks/rewriter/util/JoinUtils.java
+++ b/hyracks-fullstack/algebricks/algebricks-rewriter/src/main/java/org/apache/hyracks/algebricks/rewriter/util/JoinUtils.java
@@ -340,7 +340,7 @@ public class JoinUtils {
         return null;
     }
 
-    private static void warnIfCrossProduct(ILogicalExpression conditionExpr, SourceLocation sourceLoc,
+    public static void warnIfCrossProduct(ILogicalExpression conditionExpr, SourceLocation sourceLoc,
             IOptimizationContext context) {
         if (OperatorPropertiesUtil.isAlwaysTrueCond(conditionExpr) && sourceLoc != null) {
             IWarningCollector warningCollector = context.getWarningCollector();


### PR DESCRIPTION
  ## Problem

  When a SQL++ query uses implicit cross join syntax (e.g., `FROM customers, orders`
  without an explicit join condition), `SimpleUnnestToProductRule` rewrites the unnest
  pipeline into an `InnerJoinOperator` with a constant `TRUE` condition. However, no
  warning is emitted to alert the user that a cross product is being performed.

  By contrast, an explicit `JOIN ... ON TRUE` already triggers a `CROSS_PRODUCT_JOIN`
  warning through `JoinUtils.warnIfCrossProduct()`. This inconsistency means users of
  the implicit syntax receive no feedback about potentially expensive cross products,
  which can lead to unexpected performance issues or incorrect query results.

  ## Changes

  **`JoinUtils.java`**
  - Changed `warnIfCrossProduct()` from `private static` to `public static` so it can
    be called from outside the class.

  **`SimpleUnnestToProductRule.java`**
  - Added `import` for `JoinUtils`.
  - Added a call to `JoinUtils.warnIfCrossProduct()` immediately after the cross product
    join operator is constructed, consistent with how explicit joins are handled.

  ## Testing

  - `mvn compile` passes on the `algebricks-rewriter` module.
  - `mvn test` passes (BUILD SUCCESS) on the `algebricks-rewriter` module.

  ## Related

  - JIRA: https://issues.apache.org/jira/browse/ASTERIXDB-3021

